### PR TITLE
Add proxy route for external Flask API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Backend Proxy
+
+A Next.js API route is provided to forward requests to the external Flask service `https://flasker-jc14.onrender.com/process_image`. Use `/api/process-image` from the frontend to avoid CORS errors.

--- a/app/api/process-image/route.ts
+++ b/app/api/process-image/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_URL = "https://flasker-jc14.onrender.com/process_image";
+
+async function proxy(req: NextRequest, init: RequestInit) {
+  try {
+    const res = await fetch(API_URL + req.nextUrl.search, init);
+    const body = await res.arrayBuffer();
+    const contentType = res.headers.get("content-type") || "application/json";
+    return new NextResponse(body, {
+      status: res.status,
+      headers: {
+        "Content-Type": contentType,
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (err) {
+    console.error("Proxy error", err);
+    return NextResponse.json({ error: "Proxy request failed" }, { status: 500 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  return proxy(req, { method: "GET" });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.formData();
+  return proxy(req, { method: "POST", body });
+}
+


### PR DESCRIPTION
## Summary
- create a `/api/process-image` route that forwards requests to the Flask service and sets CORS headers
- document usage of the proxy route in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaed4ac8c832aa0c0f2e9e9619d70