### PR TITLE
Add collaborative canvas scaffold

### DIFF
--- a/canvas/README.md
+++ b/canvas/README.md
@@ -1,0 +1,53 @@
+# Collaborative Canvas Prototype
+
+This is a minimal scaffold for a real-time collaborative canvas application.
+It uses **Flask** with **Flask-SocketIO** for the web server, **Redis** for
+Pub/Sub messaging, and **PostgreSQL** for persistence. **Nginx** acts as a TLS
+terminating reverse proxy.
+
+## Structure
+
+- `docker-compose.yml` - defines services for nginx, the Flask app, Redis, and PostgreSQL.
+- `nginx/` - Dockerfile and config for the reverse proxy. Certificates should
+  be placed in `nginx/letsencrypt`.
+- `web/` - Flask application and dependencies.
+- `db/` - Postgres image customization and initialization SQL.
+- `init_db/schema.sql` - SQL schema for the `canvas_ops` table.
+
+## Quick start (single VM)
+
+1. Ensure Docker and Docker Compose are installed.
+2. Place your TLS certificates under `nginx/letsencrypt` or set up certbot
+   separately.
+3. Run:
+
+```bash
+docker compose build
+docker compose up
+```
+
+The Flask application will be available via HTTPS through Nginx.
+
+## Scaling out
+
+- Run multiple instances of the `web` service behind a load balancer.
+- Use a shared Redis instance for WebSocket message queueing (the Flask-SocketIO
+  `message_queue` option) so events propagate across instances.
+- Use a managed PostgreSQL database for persistence.
+- Nginx (or another proxy) should balance traffic across the `web` instances.
+
+## Manual steps
+
+- Obtain real TLS certificates for your domain using certbot or another ACME
+  client and place them in `nginx/letsencrypt`.
+- Adjust `nginx/default.conf` with your actual domain names.
+
+## Environment variables
+
+The `web` container uses the following variables (defined in `docker-compose.yml`):
+
+- `DATABASE_URL` – SQLAlchemy connection URI.
+- `REDIS_URL` – Redis connection string.
+- `FLASK_ENV` – environment (development/production).
+
+Adjust as needed for your environment.

--- a/canvas/db/Dockerfile
+++ b/canvas/db/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:15-alpine
+
+# Example of customizing the image
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY ../init_db/schema.sql /docker-entrypoint-initdb.d/

--- a/canvas/docker-compose.yml
+++ b/canvas/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+  nginx:
+    build: ./nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/letsencrypt:/etc/letsencrypt
+    depends_on:
+      - web
+    restart: unless-stopped
+
+  web:
+    build: ./web
+    environment:
+      - FLASK_ENV=development
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+      - REDIS_URL=redis://redis:6379/0
+    volumes:
+      - ./web/app:/app
+    depends_on:
+      - db
+      - redis
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+  db:
+    build: ./db
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+volumes:
+  db_data:

--- a/canvas/init_db/schema.sql
+++ b/canvas/init_db/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS canvas_ops (
+    id SERIAL PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    op_index INT NOT NULL,
+    op_data JSONB NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_canvas_ops_session_idx ON canvas_ops (session_id, op_index);

--- a/canvas/nginx/Dockerfile
+++ b/canvas/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:stable-alpine
+
+COPY default.conf /etc/nginx/conf.d/default.conf
+# Let's Encrypt certificates will be stored in /etc/letsencrypt (mounted)

--- a/canvas/nginx/default.conf
+++ b/canvas/nginx/default.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    server_name _;
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /socket.io/ {
+        proxy_pass http://web:5000/socket.io/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/canvas/nginx/letsencrypt/README.md
+++ b/canvas/nginx/letsencrypt/README.md
@@ -1,0 +1,1 @@
+Place your Let's Encrypt certificates here. Use certbot or another ACME client to obtain certificates for your domain.

--- a/canvas/web/Dockerfile
+++ b/canvas/web/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app /app
+
+CMD ["python", "-m", "app"]

--- a/canvas/web/app/__init__.py
+++ b/canvas/web/app/__init__.py
@@ -1,0 +1,71 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_socketio import SocketIO
+import redis
+import json
+import os
+from threading import Thread, Event
+import time
+
+socketio = SocketIO(async_mode='eventlet', cors_allowed_origins="*")
+db = SQLAlchemy()
+
+redis_client = None
+
+ops_buffer = {}
+flush_event = Event()
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    socketio.init_app(app, message_queue=os.environ.get('REDIS_URL'))
+
+    global redis_client
+    redis_client = redis.Redis.from_url(os.environ.get('REDIS_URL'))
+
+    from .routes import bp as routes_bp
+    app.register_blueprint(routes_bp)
+
+    from .sockets import register_socketio_handlers
+    register_socketio_handlers(socketio)
+
+    Thread(target=_flusher, daemon=True).start()
+
+    return app
+
+
+def buffer_op(session_id, op_index, op_data):
+    ops_buffer.setdefault(session_id, []).append((op_index, op_data))
+    flush_event.set()
+
+
+def _flusher():
+    while True:
+        flush_event.wait(timeout=5)
+        flush_event.clear()
+        for session_id, ops in list(ops_buffer.items()):
+            if not ops:
+                continue
+            with create_app().app_context():
+                for idx, data in ops:
+                    op = CanvasOp(session_id=session_id, op_index=idx, op_data=data)
+                    db.session.add(op)
+                db.session.commit()
+            ops_buffer[session_id] = []
+        time.sleep(0.1)
+
+
+class CanvasOp(db.Model):
+    __tablename__ = 'canvas_ops'
+    id = db.Column(db.Integer, primary_key=True)
+    session_id = db.Column(db.String, nullable=False)
+    op_index = db.Column(db.Integer, nullable=False)
+    op_data = db.Column(db.JSON, nullable=False)
+
+
+if __name__ == '__main__':
+    app = create_app()
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/canvas/web/app/routes.py
+++ b/canvas/web/app/routes.py
@@ -1,0 +1,18 @@
+from flask import Blueprint, request, jsonify
+from . import db, CanvasOp
+
+bp = Blueprint('routes', __name__)
+
+@bp.route('/sessions/<session_id>/ops', methods=['GET'])
+def get_ops(session_id):
+    ops = CanvasOp.query.filter_by(session_id=session_id).order_by(CanvasOp.op_index).all()
+    return jsonify([op.op_data for op in ops])
+
+@bp.route('/sessions', methods=['POST'])
+def create_session():
+    data = request.get_json() or {}
+    session_id = data.get('session_id')
+    if not session_id:
+        return jsonify({'error': 'session_id required'}), 400
+    # in a real app we would check existence / create
+    return jsonify({'session_id': session_id})

--- a/canvas/web/app/sockets.py
+++ b/canvas/web/app/sockets.py
@@ -1,0 +1,25 @@
+from flask_socketio import emit, join_room
+from . import redis_client, buffer_op
+
+
+def register_socketio_handlers(socketio):
+    @socketio.on('join')
+    def on_join(data):
+        session_id = data['session_id']
+        join_room(session_id)
+        emit('joined', {'session_id': session_id})
+
+    @socketio.on('init_state')
+    def on_init(data):
+        session_id = data['session_id']
+        # broadcast to others in room
+        emit('init_state', data, room=session_id, include_self=False)
+        redis_client.publish(f'session:{session_id}', data)
+
+    @socketio.on('draw_op')
+    def on_draw_op(data):
+        session_id = data['session_id']
+        op_index = data.get('op_index', 0)
+        buffer_op(session_id, op_index, data)
+        emit('draw_op', data, room=session_id, include_self=False)
+        redis_client.publish(f'session:{session_id}', data)

--- a/canvas/web/requirements.txt
+++ b/canvas/web/requirements.txt
@@ -1,0 +1,6 @@
+Flask==2.3.3
+Flask-SocketIO==5.3.3
+redis==4.5.5
+SQLAlchemy==2.0.20
+psycopg2-binary==2.9.7
+eventlet==0.33.3


### PR DESCRIPTION
## Summary
- add docker-compose setup for `nginx`, `web`, `redis`, and `db`
- add Dockerfiles and configs for each service
- implement Flask/Flask-SocketIO application with Redis and SQLAlchemy
- provide example PostgreSQL schema
- document usage, scaling notes, and manual TLS steps

## Testing
- `python -m py_compile canvas/web/app/*.py`
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68679c00d404832a909f5e6a5113af63