### PR TITLE
Implement challenges page with attempt tracking

### DIFF
--- a/app/challenges/page.tsx
+++ b/app/challenges/page.tsx
@@ -1,0 +1,116 @@
+import { createClient } from '@/utils/supabase/server'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table'
+
+interface Attempt {
+  id: string
+  created_at: string
+  feedback?: boolean | null
+}
+
+interface Challenge {
+  id: string
+  created_at: string
+  attempts?: Attempt[]
+}
+
+export default async function ChallengesPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/signin')
+  }
+
+  const { data: challenges, error } = await supabase
+    .from('challenges')
+    .select('id, created_at, attempts(id, created_at, feedback)')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Error fetching challenges:', error)
+    return <p className="text-center text-red-500">Could not fetch challenges.</p>
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <header className="flex justify-between items-center mb-8">
+        <h1 className="text-3xl font-bold">Your Challenges</h1>
+        <Link href="/" className="hover:text-[#FF5C38] transition-colors">
+          Back to Home
+        </Link>
+      </header>
+      {challenges && challenges.length > 0 ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Challenge</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Attempts</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(challenges as Challenge[]).map(challenge => (
+              <TableRow key={challenge.id}>
+                <TableCell className="align-top">{challenge.id}</TableCell>
+                <TableCell className="align-top">
+                  {new Date(challenge.created_at).toLocaleString()}
+                </TableCell>
+                <TableCell>
+                  {challenge.attempts && challenge.attempts.length > 0 ? (
+                    <Table className="w-full">
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Attempt</TableHead>
+                          <TableHead>Date</TableHead>
+                          <TableHead>Feedback</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {challenge.attempts.map(attempt => (
+                          <TableRow key={attempt.id}>
+                            <TableCell>{attempt.id}</TableCell>
+                            <TableCell>
+                              {new Date(attempt.created_at).toLocaleString()}
+                            </TableCell>
+                            <TableCell>
+                              {attempt.feedback ? (
+                                'Received'
+                              ) : (
+                                <Link
+                                  href={`/feedback/${attempt.id}`}
+                                  className="text-blue-600 underline"
+                                >
+                                  Give Feedback
+                                </Link>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  ) : (
+                    <span>No attempts yet</span>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <p className="text-center">You haven't created any challenges yet.</p>
+      )}
+    </div>
+  )
+}

--- a/hotdot-landing.tsx
+++ b/hotdot-landing.tsx
@@ -36,7 +36,7 @@ export default function Component() {
       <footer className="absolute bottom-8 left-6 z-10">
         <nav className="flex flex-col items-start gap-2 text-[#1A1A1A] text-[48px] md:text-[52px] font-medium leading-tight tracking-[-2%]">
           <Link href="/solo-play" className="hover:text-[#FF5C38] transition-colors">SOLO-PLAY</Link>
-          <Link href="#" className="hover:text-[#FF5C38] transition-colors">CHALLENGE</Link>
+          <Link href="/challenges" className="hover:text-[#FF5C38] transition-colors">CHALLENGE</Link>
           <Link href="#" className="hover:text-[#FF5C38] transition-colors">GUESS-IT</Link>
           <Link href="/profile" className="hover:text-[#FF5C38] transition-colors">PROFILE</Link>
         </nav>


### PR DESCRIPTION
## Summary
- add new server-side challenges page listing created challenges and attempts
- link to the challenges page from the landing footer

## Testing
- `pnpm lint` *(fails: ESLint config prompt)*
- `pnpm build` *(fails: missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_687e2eaf4d50832a91c4bdc8f1e09993