### PR TITLE
Add matchmaking and live drawing

### DIFF
--- a/app/api/match/[id]/route.ts
+++ b/app/api/match/[id]/route.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@/utils/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = await createClient();
+  const { id } = params;
+
+  const { data, error } = await supabase
+    .from('matches')
+    .select('id, challenge_id, status, creator_id, guesser_id')
+    .eq('id', id)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'match not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/app/api/match/create/route.ts
+++ b/app/api/match/create/route.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@/utils/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  const { challengeId } = await req.json();
+  const { data, error } = await supabase
+    .from('matches')
+    .insert({ creator_id: user.id, challenge_id: challengeId, status: 'waiting' })
+    .select('id')
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message || 'failed to create match' }, { status: 500 });
+  }
+
+  return NextResponse.json({ id: data.id });
+}

--- a/app/api/match/join/route.ts
+++ b/app/api/match/join/route.ts
@@ -1,0 +1,33 @@
+import { createClient } from '@/utils/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  const { data: matchData, error } = await supabase
+    .from('matches')
+    .select('id, challenge_id')
+    .eq('status', 'waiting')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .single();
+
+  if (error || !matchData) {
+    return NextResponse.json({ error: 'no match available' }, { status: 404 });
+  }
+
+  const { error: updateError } = await supabase
+    .from('matches')
+    .update({ guesser_id: user.id, status: 'active' })
+    .eq('id', matchData.id);
+
+  if (updateError) {
+    return NextResponse.json({ error: 'failed to join match' }, { status: 500 });
+  }
+
+  return NextResponse.json({ id: matchData.id, challengeId: matchData.challenge_id });
+}

--- a/app/guess-match/page.tsx
+++ b/app/guess-match/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/utils/supabase/client';
+
+export default function GuessMatchPage() {
+  const router = useRouter();
+  const supabase = createClient();
+
+  useEffect(() => {
+    const join = async () => {
+      const res = await fetch('/api/match/join', { method: 'POST' });
+      const data = await res.json();
+      if (res.ok) {
+        const channel = supabase.channel(`match-${data.id}`);
+        channel.subscribe(async status => {
+          if (status === 'SUBSCRIBED') {
+            await channel.send({ type: 'broadcast', event: 'start', payload: {} });
+            router.push(`/match/${data.id}?role=guesser&challenge=${data.challengeId}`);
+          }
+        });
+      } else {
+        console.error(data.error);
+      }
+    };
+
+    join();
+  }, [router, supabase]);
+
+  return (
+    <div className="flex items-center justify-center h-full text-xl">Finding a match...</div>
+  );
+}

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useEffect, useRef, useState } from 'react';
+import { useParams, useSearchParams } from 'next/navigation';
+import { createClient } from '@/utils/supabase/client';
+import DrawableCanvas, { DrawableCanvasRef, DrawEvent } from '@/components/drawable-canvas';
+
+export default function MatchPage() {
+  const { id } = useParams();
+  const search = useSearchParams();
+  const role = search.get('role');
+  const challengeId = search.get('challenge');
+  const canvasRef = useRef<DrawableCanvasRef>(null);
+  const supabase = createClient();
+
+  useEffect(() => {
+    if (!challengeId) return;
+    fetch(`/api/challenge/${challengeId}`).then(res => res.json()).then(data => {
+      if (data.template_svg && canvasRef.current) {
+        canvasRef.current.animateSvg(data.template_svg, data.template_viewbox);
+      }
+    });
+  }, [challengeId]);
+
+  useEffect(() => {
+    const channel = supabase.channel(`match-${id}`);
+    if (role === 'creator') {
+      channel.on('broadcast', { event: 'draw' }, payload => {
+        if (canvasRef.current) {
+          canvasRef.current.applyRemoteEvent(payload as DrawEvent);
+        }
+      });
+    }
+    channel.subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [id, role, supabase]);
+
+  const handleDraw = (event: DrawEvent) => {
+    if (role === 'guesser') {
+      supabase.channel(`match-${id}`).send({ type: 'broadcast', event: 'draw', payload: event });
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center h-full p-4">
+      <div className="w-full max-w-sm" style={{ aspectRatio: '346/562' }}>
+        <DrawableCanvas ref={canvasRef} isLocked={role !== 'guesser'} onDrawEvent={handleDraw} />
+      </div>
+    </div>
+  );
+}

--- a/app/match/[id]/waiting/page.tsx
+++ b/app/match/[id]/waiting/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useEffect } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { createClient } from '@/utils/supabase/client';
+
+export default function MatchWaitingPage() {
+  const { id } = useParams();
+  const search = useSearchParams();
+  const challengeId = search.get('challenge');
+  const router = useRouter();
+  const supabase = createClient();
+
+  useEffect(() => {
+    const channel = supabase.channel(`match-${id}`);
+    channel.on('broadcast', { event: 'start' }, () => {
+      router.push(`/match/${id}?role=creator&challenge=${challengeId}`);
+    });
+    channel.subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [id, router, supabase, challengeId]);
+
+  return (
+    <div className="flex items-center justify-center h-full text-xl">Waiting for a guesser...</div>
+  );
+}

--- a/app/solo-play/page.tsx
+++ b/app/solo-play/page.tsx
@@ -90,11 +90,21 @@ export default function SoloPlayPage() {
 
   const handleChallengeIt = () => {
     if (!template) return;
-    createChallenge(template.svgContent, template.viewBox).then((res) => {
+    createChallenge(template.svgContent, template.viewBox).then(async (res) => {
       if (res?.success && res.id) {
-        router.push(`/challenge/${res.id}/share`);
+        const matchRes = await fetch('/api/match/create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ challengeId: res.id }),
+        });
+        const matchData = await matchRes.json();
+        if (matchRes.ok) {
+          router.push(`/match/${matchData.id}/waiting?challenge=${res.id}`);
+        } else {
+          console.error(matchData.error || 'Failed to create match');
+        }
       } else {
-        console.error(res?.error || "Failed to create challenge");
+        console.error(res?.error || 'Failed to create challenge');
       }
     });
   };

--- a/hotdot-landing.tsx
+++ b/hotdot-landing.tsx
@@ -37,7 +37,7 @@ export default function Component() {
         <nav className="flex flex-col items-start gap-2 text-[#1A1A1A] text-[48px] md:text-[52px] font-medium leading-tight tracking-[-2%]">
           <Link href="/solo-play" className="hover:text-[#FF5C38] transition-colors">SOLO-PLAY</Link>
           <Link href="/challenges" className="hover:text-[#FF5C38] transition-colors">CHALLENGE</Link>
-          <Link href="#" className="hover:text-[#FF5C38] transition-colors">GUESS-IT</Link>
+          <Link href="/guess-match" className="hover:text-[#FF5C38] transition-colors">GUESS-IT</Link>
           <Link href="/profile" className="hover:text-[#FF5C38] transition-colors">PROFILE</Link>
         </nav>
       </footer>


### PR DESCRIPTION
## Summary
- link main menu GUESS-IT to new matchmaking flow
- create API routes for creating and joining matches
- update solo play to create match and wait for guesser
- implement waiting and live match pages with Supabase Realtime
- extend `DrawableCanvas` with draw event helpers

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687e3463afd8832aaa7fc86763b84562